### PR TITLE
Fix IMAP literal parsing in ENVELOPE address fields

### DIFF
--- a/lib/mailroom/imap.ex
+++ b/lib/mailroom/imap.ex
@@ -550,7 +550,7 @@ defmodule Mailroom.IMAP do
   end
 
   defp process_fetch_data(data, state) do
-    case Regex.run(~r/\A(.+ {(\d+)}\r\n)\z/sm, data) do
+    case Regex.run(~r/\A(.+{(\d+)}\r\n)\z/sm, data) do
       [_, initial, bytes] ->
         data = fetch_all_data(String.to_integer(bytes), 0, [initial], state)
         process_fetch_data(data, state)

--- a/lib/mailroom/imap/utils.ex
+++ b/lib/mailroom/imap/utils.ex
@@ -1,5 +1,7 @@
 defmodule Mailroom.IMAP.Utils do
   @moduledoc false
+  alias Mailroom.BackwardsCompatibleLogger, as: Logger
+
   def parse_list_only(string) do
     {list, _rest} = parse_list(string)
     list
@@ -29,8 +31,15 @@ defmodule Mailroom.IMAP.Utils do
   def parse_list(<<"{", rest::binary>>, depth, _temp, acc) do
     {octets, <<"\r\n", rest::binary>>} = read_until(rest, "}")
     octets = String.to_integer(octets)
-    <<string::binary-size(octets), rest::binary>> = rest
-    parse_list(rest, depth, nil, prepend_to_list(acc, string))
+
+    case rest do
+      <<string::binary-size(octets), rest::binary>> ->
+        parse_list(rest, depth, nil, prepend_to_list(acc, string))
+
+      _ ->
+        Logger.warning("parse_list: expected literal of size #{octets} but got #{inspect(rest)}")
+        {acc, rest}
+    end
   end
 
   def parse_list(<<" ", rest::binary>>, depth, nil, acc),
@@ -47,6 +56,9 @@ defmodule Mailroom.IMAP.Utils do
 
   def parse_list(<<char::utf8, rest::binary>>, depth, temp, acc),
     do: parse_list(rest, depth, <<temp::binary, char>>, acc)
+
+  def parse_list(<<>>, _depth, temp, acc),
+    do: {Enum.reverse(prepend_to_list(acc, temp)), <<>>}
 
   defp prepend_to_list(nil, item), do: List.wrap(item)
   defp prepend_to_list(list, nil), do: list

--- a/lib/mailroom/inbox.ex
+++ b/lib/mailroom/inbox.ex
@@ -124,7 +124,9 @@ defmodule Mailroom.Inbox do
         IMAP.idle(client, self(), :idle_notify)
       end
 
-      defoverridable config: 1
+      def on_envelope_error(_msg_id, _response, _assigns), do: :ok
+
+      defoverridable config: 1, on_envelope_error: 3
     end
   end
 
@@ -218,6 +220,7 @@ defmodule Mailroom.Inbox do
                   "Unable to process envelope #{inspect(response)}"
                 end)
 
+                on_envelope_error(msg_id, response, assigns)
                 Mailroom.IMAP.add_flags(client, msg_id, [:seen])
 
               mail_info ->

--- a/test/mailroom/imap/utils_test.exs
+++ b/test/mailroom/imap/utils_test.exs
@@ -189,4 +189,44 @@ defmodule Mailroom.IMAP.UtilsTest do
   test "parse_timestamp/1" do
     assert parse_timestamp("21-Jun-2018 17:51:47 +0000") == ~U"2018-06-21 17:51:47Z"
   end
+
+  describe "parse_list/1 with IMAP literals" do
+    test "with literal string containing full content" do
+      assert parse_list("(name {5}\r\nhello rest)") == {["name", "hello", "rest"], ""}
+    end
+
+    test "with literal string in nested ENVELOPE address structure" do
+      envelope_sender = "(({23}\r\nJohn  Doe - Company Inc NIL \"user\" \"example.com\"))"
+      {result, _rest} = parse_list(envelope_sender)
+      assert result == [["John  Doe - Company Inc", nil, "user", "example.com"]]
+    end
+
+    test "with literal string where content is truncated" do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          assert {[[]], ""} = parse_list("(({23}\r\n")
+        end)
+
+      assert log =~ "parse_list: expected literal of size 23"
+    end
+
+    test "with literal string where content is partially present" do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          assert {[[], "John", "Doe"], ""} = parse_list("(({23}\r\nJohn  Doe ")
+        end)
+
+      assert log =~ "parse_list: expected literal of size 23"
+    end
+  end
+
+  describe "parse_list/1 with empty binary" do
+    test "returns accumulated result" do
+      assert parse_list("") == {[], ""}
+    end
+  end
 end

--- a/test/mailroom/imap_test.exs
+++ b/test/mailroom/imap_test.exs
@@ -1698,4 +1698,53 @@ defmodule Mailroom.IMAPTest do
                debug: @debug
              )
   end
+
+  test "FETCH with IMAP literal in ENVELOPE address (no space before {)" do
+    server = TestServer.start(ssl: true)
+
+    TestServer.expect(server, fn expectations ->
+      expectations
+      |> TestServer.tagged(:connect, "* OK IMAP ready\r\n")
+      |> TestServer.tagged("LOGIN \"test@example.com\" \"P@55w0rD\"\r\n", [
+        "* CAPABILITY (IMAPrev4)\r\n",
+        "OK test@example.com authenticated (Success)\r\n"
+      ])
+      |> TestServer.tagged("SELECT INBOX\r\n", [
+        "* FLAGS (\\Flagged \\Draft \\Deleted \\Seen)\r\n",
+        "* OK [PERMANENTFLAGS (\\Flagged \\Draft \\Deleted \\Seen \\*)] Flags permitted\r\n",
+        "* 2 EXISTS\r\n",
+        "* 1 RECENT\r\n",
+        "OK [READ-WRITE] INBOX selected. (Success)\r\n"
+      ])
+      |> TestServer.tagged("FETCH 1 (ENVELOPE)\r\n", [
+        "* 1 FETCH (ENVELOPE (\"Tue, 10 Mar 2026 14:54:44 +0000\" \"FW: Invoices\" (({21}\r\nJane  Doe - ACME Corp NIL \"j.doe\" \"acme-example.ch\")) ((\"app-test@messaging.test-system.net\" NIL \"app-test\" \"messaging.test-system.net\")) ((\"app-test@messaging.test-system.net\" NIL \"app-test\" \"messaging.test-system.net\")) ((\"app-test@messaging.test-system.net\" NIL \"app-test\" \"messaging.test-system.net\")) NIL NIL \"<ref-id@outlook.com>\" \"<msg-id@outlook.com>\"))\r\n",
+        "OK Success\r\n"
+      ])
+      |> TestServer.tagged("LOGOUT\r\n", [
+        "* BYE We're out of here\r\n",
+        "OK Logged out\r\n"
+      ])
+    end)
+
+    assert {:ok, client} =
+             IMAP.connect(server.address, "test@example.com", "P@55w0rD",
+               port: server.port,
+               ssl: true,
+               ssl_opts: [verify: :verify_none],
+               debug: @debug
+             )
+
+    {:ok, msgs} =
+      client
+      |> IMAP.select(:inbox)
+      |> IMAP.fetch(1, :envelope)
+
+    assert [{1, %{envelope: %Mailroom.IMAP.Envelope{} = envelope}}] = msgs
+    assert envelope.subject == "FW: Invoices"
+
+    assert [%{email: "j.doe@acme-example.ch", name: "Jane  Doe - ACME Corp"}] =
+             envelope.from
+
+    IMAP.logout(client)
+  end
 end


### PR DESCRIPTION
## Problem

IMAP ENVELOPE responses containing literal strings in address fields (e.g. sender display names with special characters) were not parsed correctly. The process_fetch_data regex required a space before {N}\r\n, but address fields use (({N}\r\n... (parenthesis, no space).

This caused 'Unable to process envelope' errors for affected emails.

## Changes

- imap.ex: Fixed process_fetch_data regex (.+{ instead of .+ {)
- imap/utils.ex: Made parse_list literal handling graceful (logs warning instead of crashing on incomplete data). Added empty binary clause.
- inbox.ex: Added on_envelope_error/3 overridable callback for consumers to handle envelope parsing failures.

## Tests

- 6 new tests (utils literal parsing, IMAP integration, empty binary)
- All 107 tests pass